### PR TITLE
remove map_server node from tr_05_navigation.launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# ROS package for TR05 seires
+
+> Please visit [HomePage](http://cn.robostore.me/products-serch/Abel05) for more infomation.

--- a/tr05_navigation/launch/tr05_navigation.launch
+++ b/tr05_navigation/launch/tr05_navigation.launch
@@ -36,8 +36,9 @@
     </include>
     -->
 
-    <node pkg="map_server" type="map_server" name="map_server"
-        args="$(find tr05_navigation)/maps/mymap2.yaml" />
+    <!-- map_server now managed by user or application service -->
+    <!-- <node pkg="map_server" type="map_server" name="map_server"
+        args="$(find tr05_navigation)/maps/mymap2.yaml" /> -->
 
     <node pkg="amcl" type="amcl" name="amcl" >
         <remap from="scan" to="scan" />


### PR DESCRIPTION
- map_server node now should managed by the HMI application service;
- and update README;